### PR TITLE
Move __precompile__ outside of the module

### DIFF
--- a/src/Bukdu.jl
+++ b/src/Bukdu.jl
@@ -1,6 +1,6 @@
-module Bukdu
-
 __precompile__(true)
+
+module Bukdu
 
 include("exports.jl")
 


### PR DESCRIPTION
The line has to be on the outside in order to precompile the module.

Edit: Actually, someone has corrected me on that; it actually does not have to be outside of the module (though putting it inside requires parsing the module twice). So I guess this is more of a stylistic change that would make it consistent with the majority of the package ecosystem, which has it on the outside.
